### PR TITLE
mutex: Declare connector with new syntax

### DIFF
--- a/apps/mutex/CMakeLists.txt
+++ b/apps/mutex/CMakeLists.txt
@@ -18,5 +18,5 @@ DeclareCAmkESComponent(A SOURCES components/A/src/main.c)
 DeclareCAmkESComponent(B SOURCES components/B/src/main.c)
 
 CAmkESAddTemplatesPath(templates)
-
+DeclareCAmkESConnector(seL4MyConnector FROM seL4MyConnector-from.c TO seL4MyConnector-to.c)
 DeclareCAmkESRootserver(mutex.camkes)

--- a/apps/mutex/mutex.camkes
+++ b/apps/mutex/mutex.camkes
@@ -16,8 +16,8 @@ import "components/A/A.camkes";
 import "components/B/B.camkes";
 
 connector seL4MyConnector {
-    from Procedure template "seL4MyConnector-from.c";
-    to Procedure template "seL4MyConnector-to.c";
+    from Procedure;
+    to Procedure;
 
     attribute string isabelle_connector_spec = "\<lparr>
         connector_type = NativeConnector,


### PR DESCRIPTION
The syntax for declaring a connector now requires the template to be
specified in CMake.