### PR TITLE
trivial: Declare RUMPRUN_PATH in settings.cmake

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -26,6 +26,7 @@ list(
 set(PICOTCP_PATH "${project_dir}/projects/picotcp" CACHE INTERNAL "")
 set(BBL_PATH ${project_dir}/tools/riscv-pk CACHE STRING "BBL Folder location")
 set(COGENT_PATH ${project_dir}/tools/cogent/cogent CACHE INTERNAL "")
+set(RUMPRUN_PATH ${project_dir}/tools/rumprun CACHE INTERNAL "")
 
 set(SEL4_CONFIG_DEFAULT_ADVANCED ON)
 


### PR DESCRIPTION
This is so that the rumprun project can be found.

Signed-off-by: Kent McLeod <kent.mcleod@protonmail.com>