### PR TITLE
picoserver: Create settings.cmake

### DIFF
--- a/apps/picoserver/CMakeLists.txt
+++ b/apps/picoserver/CMakeLists.txt
@@ -10,22 +10,6 @@ project(picoserver C)
 
 includeGlobalComponents()
 
-set(LibPicotcp ON CACHE BOOL "" FORCE)
-set(LibPicotcpBsd OFF CACHE BOOL "" FORCE)
-set(LibEthdriverNumPreallocatedBuffers 32 CACHE STRING "" FORCE)
-
-# For x86, we map DMA frames into the IOMMU to use as buffers for the
-# Ethernet device. The VKA and VSpace libraries do not like pages that
-# are not 4K in size.
-set(CAmkESDMALargeFramePromotion OFF CACHE BOOL "" FORCE)
-
-# The app has only been tested on hardware, and not on QEMU
-set(SIMULATION OFF CACHE BOOL "" FORCE)
-if("${KernelArch}" STREQUAL "x86")
-    # The IOMMU is required for the Ethdriver component on x86
-    set(KernelIOMMU ON CACHE BOOL "" FORCE)
-endif()
-
 set(CAmkESCPP ON CACHE BOOL "" FORCE)
 if("${KernelArch}" STREQUAL "x86")
     set(cpp_define -DKernelArchX86)

--- a/apps/picoserver/settings.cmake
+++ b/apps/picoserver/settings.cmake
@@ -1,0 +1,21 @@
+#
+# Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+set(LibPicotcp ON CACHE BOOL "" FORCE)
+set(LibPicotcpBsd OFF CACHE BOOL "" FORCE)
+set(LibEthdriverNumPreallocatedBuffers 32 CACHE STRING "" FORCE)
+
+# For x86, we map DMA frames into the IOMMU to use as buffers for the
+# Ethernet device. The VKA and VSpace libraries do not like pages that
+# are not 4K in size.
+set(CAmkESDMALargeFramePromotion OFF CACHE BOOL "" FORCE)
+
+# The app has only been tested on hardware, and not on QEMU
+set(SIMULATION OFF CACHE BOOL "" FORCE)
+if("${KernelArch}" STREQUAL "x86")
+    # The IOMMU is required for the Ethdriver component on x86
+    set(KernelIOMMU ON CACHE BOOL "" FORCE)
+endif()


### PR DESCRIPTION
Setting LibPicotcp=ON in a settings.cmake will remove picotcp
compilation errors when this app configuration is built.

Signed-off-by: Kent McLeod <kent@kry10.com>