### PR TITLE
Turn on KernelExportPMCUser in picotcp apps

### DIFF
--- a/apps/picotcp_single_component/settings.cmake
+++ b/apps/picotcp_single_component/settings.cmake
@@ -22,3 +22,5 @@ endif()
 set(LibEthdriverRXDescCount 256 CACHE STRING "" FORCE)
 set(LibEthdriverTXDescCount 256 CACHE STRING "" FORCE)
 set(CAmkESNoFPUByDefault ON CACHE BOOL "" FORCE)
+
+set(KernelExportPMCUser ON CACHE BOOL "" FORCE)

--- a/apps/picotcp_tcp_echo/settings.cmake
+++ b/apps/picotcp_tcp_echo/settings.cmake
@@ -23,3 +23,5 @@ endif()
 set(LibEthdriverRXDescCount 256 CACHE STRING "" FORCE)
 set(LibEthdriverTXDescCount 512 CACHE STRING "" FORCE)
 set(CAmkESNoFPUByDefault ON CACHE BOOL "" FORCE)
+
+set(KernelExportPMCUser ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
When trying to build `picotcp_single_component` for x86_64, I get the following linker errors:

```
/nix/store/8fp4y8kvs8ydswag15cx1dspgbpz10yi-gcc-arm-embedded-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/
bin/ld: CMakeFiles/bench.instance.bin.dir/bench/camkes.environment.c.obj: in function `component_control_main':
/home/user/camkes-manifest/picotcp_single_component/bench/camkes.environment.c:34: undefined reference to `run'
/nix/store/8fp4y8kvs8ydswag15cx1dspgbpz10yi-gcc-arm-embedded-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/
bin/ld: CMakeFiles/bench.instance.bin.dir/bench/idle_seL4RPCCall_0.c.obj: in function `idle__run':
/home/user/camkes-manifest/picotcp_single_component/bench/idle_seL4RPCCall_0.c:396: undefined reference to `idle_start'
/nix/store/8fp4y8kvs8ydswag15cx1dspgbpz10yi-gcc-arm-embedded-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/
bin/ld: /home/user/camkes-manifest/picotcp_single_component/bench/idle_seL4RPCCall_0.c:431: undefined reference to `idle_stop'
```

These seem to occur because `BenchUtiliz` from [`global_components`](https://github.com/seL4/global-components) is not being linked in. Relatedly, I get this message when running cmake: `BenchUtiliz not available, as KernelExportPMCUser is OFF`.

This branch turns `KernelExportPMCUser` on in both picoserver examples, which allows linking to complete successfully.