### PR TITLE
arm,cmake: Set compiler expected tls settings

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -77,6 +77,11 @@ endif()
 
 ApplyCommonReleaseVerificationSettings(${RELEASE} FALSE)
 
+if (KernelSel4ArchAarch32)
+    # Set correct aarch32 TLS register config
+    set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+endif()
+
 # If an application specific settings file exists then import it here.
 # This can be used for applications to configure the kernel in specific ways
 include(${CMAKE_CURRENT_LIST_DIR}/apps/${CAMKES_APP}/settings.cmake OPTIONAL)


### PR DESCRIPTION
Add the right TLS variable settings for the gnu-elf-abi used by our compilers.