### PR TITLE
easy-settings: leave SIMULATION unchanged

### DIFF
--- a/easy-settings.cmake
+++ b/easy-settings.cmake
@@ -20,6 +20,5 @@
 # ninja
 #
 set(CAMKES_APP "adder" CACHE STRING "CAmkES application to build")
-set(SIMULATION ON CACHE BOOL "Try and use simulable features")
 set(RELEASE OFF CACHE BOOL "Performance optimized build")
 set(PLATFORM "x86_64" CACHE STRING "Platform to use")


### PR DESCRIPTION
Do not provide SIMULATION ON by default. This avoids surprising compilation failures on platforms that do not support simulation settings.

See also https://github.com/seL4/util_libs/pull/198 and https://github.com/seL4/util_libs/pull/196/files#r2178857087